### PR TITLE
Add workouts searching, filtering and ordering

### DIFF
--- a/backend/gymshareapi/settings.py
+++ b/backend/gymshareapi/settings.py
@@ -28,6 +28,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_filters',
     'drf_yasg',
     'rest_framework',
     'django_rest_passwordreset',
@@ -146,7 +147,7 @@ REST_FRAMEWORK  = {
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
-    )
+    ),
 }
 
 # CSRF Trusted origins

--- a/backend/workouts/views.py
+++ b/backend/workouts/views.py
@@ -1,4 +1,6 @@
-from rest_framework import viewsets, permissions
+from rest_framework import viewsets, permissions, filters
+from django_filters.rest_framework import DjangoFilterBackend
+from django.db.models import Q, When, Case
 
 from . import serializers, models
 
@@ -25,6 +27,10 @@ class WorkoutViewSet(viewsets.ModelViewSet):
     """
     queryset = models.Workout.objects.all()
     serializer_class = serializers.WorkoutSerializer
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ['title', 'description', 'author__username']
+    filterset_fields = ['visibility',]
+    ordering_fields = ['title', 'sum_of_cb', 'difficulty', 'avg_time']
 
     def get_permissions(self):
         if self.action in ['create', 'update', 'partial_update', 'destroy']:
@@ -33,6 +39,14 @@ class WorkoutViewSet(viewsets.ModelViewSet):
             self.permission_classes = [permissions.AllowAny]
 
         return super().get_permissions()
+
+    def get_queryset(self):
+        queryset_for_hidden = (Q(visibility=models.Workout.HIDDEN) & Q(author=self.request.user))
+        queryset_for_public = Q(visibility=models.Workout.PUBLIC)
+
+        if self.request.user.is_anonymous:
+            return self.queryset.filter( queryset_for_public )    
+        return self.queryset.filter( queryset_for_public | queryset_for_hidden )
 
 
 class ExerciseInWorkoutViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
- add workouts filtering, searching and ordering

### URL endpointu powinno wygladac tak
`/workouts/plans/?search=?visibility=?ordering=`

jak wszystkie pozostawicie puste to poleci domyslnie wszystko

**search** po prostu wrzucacie strina i on bd dopasowywać tego stringa do tytułów, opisów i nazwy autora

**visibility** przyjmuje tylko dwie wartosci **Public** i **Hidden** (zrobiłem je tylko po to, żeby mozna bylo latwo dodac zakladke moje workouty w profilu usera bo da sie tam wtedy endpoint `/workouts/plans/?search=?visibility=Hidden?ordering=`)

ordering przyjmuje rozne scisle okreslowe wartosci do sortowania wyszukiwania
- **title** sortowanie rosnace po tytule
- **-title** sort. malejace po tytule
- **sum_of_cb** sort. rosn. po sumie spalonych kcal
- **-sum_of_cb** sort. mal. 
- **difficulty** sort. rosn. po poziomie trudnosci
- **-difficulty** sort. mal. po poziomie trudnosci
- **avg_time** sort. rosn. po srednim czasie
- **-avg_time** sort. mal. po srednim czasie

przykladowy request jak laczyc
`/workouts/plans/?ordering=avg_time&visibility=Public?search=test`

important notes jak w search chcecice dać spacje to syntax bd troche pokurwiony, wiec lepiej poszukajcie wtyczke do reacta czy cos bo tam mi wygenerowal backend przyklad: 
`/workouts/plans/?search=papaj+nic+nie+wiedzial+o+kremowkach`
